### PR TITLE
fix: remove deployment paths on application deactivation

### DIFF
--- a/at.D365.PowerCID.Portal/ClientApp/src/app/shared/services/application.service.ts
+++ b/at.D365.PowerCID.Portal/ClientApp/src/app/shared/services/application.service.ts
@@ -113,10 +113,6 @@ export class ApplicationService {
     });
   }
 
-  public delete(id: number): Promise<void>{
-    return this.getStore().remove(id);
-  }
-
   public setDeactivated(id: number, isDeactive: boolean): Promise<void> {
     return Promise.resolve(this.getStore().update(id, { IsDeactive: isDeactive }))
       .then(() => undefined);

--- a/at.D365.PowerCID.Portal/Controllers/ApplicationsController.cs
+++ b/at.D365.PowerCID.Portal/Controllers/ApplicationsController.cs
@@ -169,7 +169,7 @@ namespace at.D365.PowerCID.Portal.Controllers
         private async Task RemoveApplicationDeploymentPaths(int applicationId)
         {
             var applicationDeploymentPaths = await this.dbContext.ApplicationDeploymentPaths
-                .Where(e => e.Application == applicationId)
+                .Where(e => e.Application == applicationId && e.ApplicationNavigation.DevelopmentEnvironmentNavigation.TenantNavigation.MsId == this.msIdTenantCurrentUser)
                 .ToListAsync();
             this.dbContext.ApplicationDeploymentPaths.RemoveRange(applicationDeploymentPaths);
         }

--- a/at.D365.PowerCID.Portal/Controllers/ApplicationsController.cs
+++ b/at.D365.PowerCID.Portal/Controllers/ApplicationsController.cs
@@ -140,9 +140,9 @@ namespace at.D365.PowerCID.Portal.Controllers
             {
                 return NotFound();
             }
-            var wasDeactive = entity.IsDeactive;
+            var wasDeactivated = entity.IsDeactive;
             application.Patch(entity);
-            if (!wasDeactive && entity.IsDeactive)
+            if (!wasDeactivated && entity.IsDeactive)
             {
                 await RemoveApplicationDeploymentPaths(entity.Id);
             }

--- a/at.D365.PowerCID.Portal/Controllers/ApplicationsController.cs
+++ b/at.D365.PowerCID.Portal/Controllers/ApplicationsController.cs
@@ -140,7 +140,12 @@ namespace at.D365.PowerCID.Portal.Controllers
             {
                 return NotFound();
             }
+            var wasDeactive = entity.IsDeactive;
             application.Patch(entity);
+            if (!wasDeactive && entity.IsDeactive)
+            {
+                await RemoveApplicationDeploymentPaths(entity.Id);
+            }
             try
             {
                 await base.dbContext.SaveChangesAsync();
@@ -161,28 +166,12 @@ namespace at.D365.PowerCID.Portal.Controllers
             return Updated(entity);
         }
 
-        [Authorize(Roles = "atPowerCID.Admin")]
-        public async Task<IActionResult> Delete([FromODataUri] int key)
+        private async Task RemoveApplicationDeploymentPaths(int applicationId)
         {
-            logger.LogDebug($"Begin: ApplicationsController Delete(key: {key})");
-
-            var application = await this.dbContext.Applications.FindAsync(key);
-            
-            if (application == null)
-                return NotFound();
-
-            if (application.DevelopmentEnvironmentNavigation.TenantNavigation.MsId != this.msIdTenantCurrentUser)
-                return Forbid();
-
-            if (application == null)
-                return NotFound();
-
-            application.IsDeactive = true;
-            await dbContext.SaveChangesAsync();
-
-            logger.LogDebug($"End: ApplicationsController Delete(key: {key})");
-
-            return Ok();
+            var applicationDeploymentPaths = await this.dbContext.ApplicationDeploymentPaths
+                .Where(e => e.Application == applicationId)
+                .ToListAsync();
+            this.dbContext.ApplicationDeploymentPaths.RemoveRange(applicationDeploymentPaths);
         }
 
         [HttpPost]


### PR DESCRIPTION
Delete application deployment path links when an application is deactivated and remove the unused application delete endpoint and client method.\n\nIssue: #286\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>