### PR TITLE
feat: group applications in solution overview

### DIFF
--- a/at.D365.PowerCID.Portal/ClientApp/src/app/components/application/application.component.html
+++ b/at.D365.PowerCID.Portal/ClientApp/src/app/components/application/application.component.html
@@ -102,12 +102,14 @@
       </dxi-column>
 
       <dxi-column
-       dataField="Group"
-       caption="Group"
-       [groupIndex]="0"
-       [showWhenGrouped]="true"
-       [allowSearch]="true"
-      ></dxi-column>
+        dataField="Group"
+        caption="Group"
+        [groupIndex]="0"
+        [showWhenGrouped]="true"
+        [allowSearch]="true"
+      >
+        <dxi-validation-rule type="stringLength" [max]="100" message="Must not be longer than 100 characters"></dxi-validation-rule>
+      </dxi-column>
 
       <dxi-column [width]="150" type="buttons">
         <dxi-button name="edit" [visible]="isActiveApplication"></dxi-button>

--- a/at.D365.PowerCID.Portal/ClientApp/src/app/components/application/application.component.html
+++ b/at.D365.PowerCID.Portal/ClientApp/src/app/components/application/application.component.html
@@ -101,6 +101,14 @@
         <dxi-validation-rule type="stringLength" [max]="5000" message="Must not be longer than 5,000 characters"> </dxi-validation-rule>
       </dxi-column>
 
+      <dxi-column
+       dataField="Group"
+       caption="Group"
+       [groupIndex]="0"
+       [showWhenGrouped]="true"
+       [allowSearch]="true"
+      ></dxi-column>
+
       <dxi-column [width]="150" type="buttons">
         <dxi-button name="edit" [visible]="isActiveApplication"></dxi-button>
         <dxi-button icon="folder" text="Open in make.powerapps.com" [visible]="isActiveApplication" [onClick]="onClickOpenMakerPortal"> </dxi-button>

--- a/at.D365.PowerCID.Portal/ClientApp/src/app/components/solutions-overview/solutions-overview.component.css
+++ b/at.D365.PowerCID.Portal/ClientApp/src/app/components/solutions-overview/solutions-overview.component.css
@@ -2,6 +2,10 @@
   min-width: 180px;
 }
 
+.solutions-selection-toolbar {
+  margin-bottom: 8px;
+}
+
 .card {
   position: relative;
   background-color: white;

--- a/at.D365.PowerCID.Portal/ClientApp/src/app/components/solutions-overview/solutions-overview.component.html
+++ b/at.D365.PowerCID.Portal/ClientApp/src/app/components/solutions-overview/solutions-overview.component.html
@@ -1,7 +1,11 @@
 <h1>Solutions Overview</h1>
+<dx-toolbar
+  [items]="selectionToolbarItems"
+  class="solutions-selection-toolbar"
+></dx-toolbar>
 <dx-data-grid
   #solutionsGrid
-  *ngIf="this.userService.currentDbUserWithTenant"
+  *ngIf="this.userService.currentDbUserWithTenant && showSolutionsGrid"
   [dataSource]="dataSourceSolutions"
   [columns]="dataGridColumns"
   [showBorders]="true"
@@ -13,7 +17,6 @@
   [allowColumnReordering]="false"
   [scrolling]="{ mode: 'infinite' }"
   height="100%"
-  (onToolbarPreparing)="onToolbarPreparingSolutionsGrid($event)"
 >
   <div *dxTemplate="let cellInfo of 'typeCellTemplate'">
     <div class="card dx-card dx-theme-text-color" [ngClass]="cellInfo.data.WasDeleted === true ? 'deleted-patch' : ''">

--- a/at.D365.PowerCID.Portal/ClientApp/src/app/components/solutions-overview/solutions-overview.component.ts
+++ b/at.D365.PowerCID.Portal/ClientApp/src/app/components/solutions-overview/solutions-overview.component.ts
@@ -54,7 +54,6 @@ export class SolutionsOverviewComponent implements OnInit, OnDestroy {
   public addPatchButtonInstance: dxButton;
   public addUpgradeButtonInstance: dxButton;
   public dataSourceSolutions: DataSource;
-  public dataSourceApplications: DataSource;
   public showSolutionsGrid = true;
   public applicationGroups: string[] = [];
   public selectedApplicationGroup = ungroupedApplicationLabel;
@@ -91,14 +90,6 @@ export class SolutionsOverviewComponent implements OnInit, OnDestroy {
     private layoutService: LayoutService,
     private patchService: PatchService
   ) {
-    this.dataSourceApplications = new DataSource({
-      store: this.applicationService.getStore(),
-      sort: [
-        { selector: "OrdinalNumber", desc: false },
-        { selector: "Name", desc: false },
-      ],
-      filter: [ "IsDeactive", "=", false ]
-    });
     this.selectionToolbarItems = this.createSelectionToolbarItems();
     this.applicationService.getStore().load({
       filter: ["IsDeactive", "=", false],

--- a/at.D365.PowerCID.Portal/ClientApp/src/app/components/solutions-overview/solutions-overview.component.ts
+++ b/at.D365.PowerCID.Portal/ClientApp/src/app/components/solutions-overview/solutions-overview.component.ts
@@ -96,6 +96,9 @@ export class SolutionsOverviewComponent implements OnInit, OnDestroy {
     private patchService: PatchService
   ) {
     this.selectionToolbarItems = this.createSelectionToolbarItems();
+    this.userService.stateChanged$.subscribe(() => {
+      this.selectionToolbarItems = this.createSelectionToolbarItems();
+    });
     this.applicationService.getStore().load({
       filter: ["IsDeactive", "=", false],
       select: ["Group"],
@@ -692,7 +695,7 @@ export class SolutionsOverviewComponent implements OnInit, OnDestroy {
         },
       ];
 
-      if (!this.userService.currentDbUserWithTenant.TenantNavigation.DisablePatchCreation) {
+      if (this.userService.currentDbUserWithTenant?.TenantNavigation.DisablePatchCreation === false) {
         items.push({
           location: "before",
           widget: "dxButton",

--- a/at.D365.PowerCID.Portal/ClientApp/src/app/components/solutions-overview/solutions-overview.component.ts
+++ b/at.D365.PowerCID.Portal/ClientApp/src/app/components/solutions-overview/solutions-overview.component.ts
@@ -29,7 +29,12 @@ type SolutionRowData = Solution & {
   ApplyManually?: unknown;
 };
 
-const ungroupedApplicationLabel = "ungruppiert";
+const ungroupedApplicationText = "Ungrouped";
+
+interface ApplicationGroupOption {
+  value: string | null;
+  text: string;
+}
 
 interface SolutionCellInfo {
   data: SolutionRowData;
@@ -55,8 +60,8 @@ export class SolutionsOverviewComponent implements OnInit, OnDestroy {
   public addUpgradeButtonInstance: dxButton;
   public dataSourceSolutions: DataSource;
   public showSolutionsGrid = true;
-  public applicationGroups: string[] = [];
-  public selectedApplicationGroup = ungroupedApplicationLabel;
+  public applicationGroups: ApplicationGroupOption[] = [];
+  public selectedApplicationGroup: string | null = null;
   public groupSelectBoxInstance: dxSelectBox;
   public selectionToolbarItems: unknown[] = [];
   public dataGridColumns: Column[] = [
@@ -96,12 +101,20 @@ export class SolutionsOverviewComponent implements OnInit, OnDestroy {
       select: ["Group"],
       sort: "Group",
     }).then((applications: Application[]) => {
-      this.applicationGroups = [...new Set(
-        applications
-          .map((application) => application.Group)
-          .filter((group): group is string => !!group)
-      )];
-      this.applicationGroups.unshift(ungroupedApplicationLabel);
+      this.applicationGroups = [
+        {
+          value: null,
+          text: ungroupedApplicationText,
+        },
+        ...[...new Set(
+          applications
+            .map((application) => application.Group)
+            .filter((group): group is string => !!group)
+        )].map((group) => ({
+          value: group,
+          text: group,
+        })),
+      ];
       this.groupSelectBoxInstance?.option("items", this.applicationGroups);
     });
     this.environmentService
@@ -570,7 +583,7 @@ export class SolutionsOverviewComponent implements OnInit, OnDestroy {
 
       this.applicationService.getApplicationById(id).then((application) => {
         this.selectedApplication = application;
-        this.selectedApplicationGroup = this.selectedApplication.Group ?? ungroupedApplicationLabel;
+        this.selectedApplicationGroup = this.selectedApplication.Group ?? null;
         this.groupSelectBoxInstance?.option(
           "value",
           this.selectedApplicationGroup
@@ -606,16 +619,14 @@ export class SolutionsOverviewComponent implements OnInit, OnDestroy {
     }
   }
 
-  private createApplicationDataSource(group: string): DataSource {
-      const filter = group === ungroupedApplicationLabel
+  private createApplicationDataSource(group: string | null): DataSource {
+      const filter = group == null
         ? [
           ["IsDeactive", "=", false],
           "and",
           [["Group", "=", null], "or", ["Group", "=", ""]],
         ]
-        : group == null
-          ? ["IsDeactive", "=", false]
-          : [["IsDeactive", "=", false], "and", ["Group", "=", group]];
+        : [["IsDeactive", "=", false], "and", ["Group", "=", group]];
 
       return new DataSource({
         store: this.applicationService.getStore(),
@@ -636,13 +647,15 @@ export class SolutionsOverviewComponent implements OnInit, OnDestroy {
             placeholder: "Select Group",
             hint: "Select an application group.",
             items: this.applicationGroups,
+            displayExpr: "text",
+            valueExpr: "value",
             value: this.selectedApplicationGroup,
             width: "220",
             onInitialized: (args: SelectBoxInitializedEvent) => {
               this.groupSelectBoxInstance = args.component;
             },
             onValueChanged: (e) => {
-              const selectedApplicationGroup = this.selectedApplication?.Group ?? ungroupedApplicationLabel;
+              const selectedApplicationGroup = this.selectedApplication?.Group ?? null;
               if (this.selectedApplication != null && e.value === selectedApplicationGroup) {
                 return;
               }

--- a/at.D365.PowerCID.Portal/ClientApp/src/app/components/solutions-overview/solutions-overview.component.ts
+++ b/at.D365.PowerCID.Portal/ClientApp/src/app/components/solutions-overview/solutions-overview.component.ts
@@ -29,6 +29,8 @@ type SolutionRowData = Solution & {
   ApplyManually?: unknown;
 };
 
+const ungroupedApplicationLabel = "ungruppiert";
+
 interface SolutionCellInfo {
   data: SolutionRowData;
   column: {
@@ -53,6 +55,11 @@ export class SolutionsOverviewComponent implements OnInit, OnDestroy {
   public addUpgradeButtonInstance: dxButton;
   public dataSourceSolutions: DataSource;
   public dataSourceApplications: DataSource;
+  public showSolutionsGrid = true;
+  public applicationGroups: string[] = [];
+  public selectedApplicationGroup = ungroupedApplicationLabel;
+  public groupSelectBoxInstance: dxSelectBox;
+  public selectionToolbarItems: unknown[] = [];
   public dataGridColumns: Column[] = [
     {
       caption: "Please select an application",
@@ -92,6 +99,20 @@ export class SolutionsOverviewComponent implements OnInit, OnDestroy {
       ],
       filter: [ "IsDeactive", "=", false ]
     });
+    this.selectionToolbarItems = this.createSelectionToolbarItems();
+    this.applicationService.getStore().load({
+      filter: ["IsDeactive", "=", false],
+      select: ["Group"],
+      sort: "Group",
+    }).then((applications: Application[]) => {
+      this.applicationGroups = [...new Set(
+        applications
+          .map((application) => application.Group)
+          .filter((group): group is string => !!group)
+      )];
+      this.applicationGroups.unshift(ungroupedApplicationLabel);
+      this.groupSelectBoxInstance?.option("items", this.applicationGroups);
+    });
     this.environmentService
       .getStore()
       .load()
@@ -109,112 +130,6 @@ export class SolutionsOverviewComponent implements OnInit, OnDestroy {
 
   public ngOnDestroy(): void {
     this.cancelAutoRefresh();
-  }
-
-  public onToolbarPreparingSolutionsGrid(e): void {
-    const toolbarItems = e.toolbarOptions.items;
-
-    toolbarItems.unshift(
-      {
-        location: "after",
-        widget: "dxButton",
-        options: {
-          icon: "assets/animations/loading.gif",
-          text: "auto-refresh is active",
-          stylingMode: "text",
-          disabled: true,
-          visible: this.autoRefreshInterval != undefined,
-          onInitialized: (args: ButtonInitializedEvent) => {
-            this.autoRefreshHintButtonInstance = args.component;
-          },
-        },
-      },
-      {
-        location: "after",
-        widget: "dxButton",
-        options: {
-          icon: "clear",
-          stylingMode: "contained",
-          type: "success",
-          onClick: this.onClickCancelAutoRefresh.bind(this),
-          visible: this.autoRefreshInterval != undefined,
-          onInitialized: (args: ButtonInitializedEvent) => {
-            this.autoRefreshCancelButtonInstance = args.component;
-          },
-        },
-      },
-      {
-        widget: "dxButton",
-        options: {
-          icon: "refresh",
-          stylingMode: "contained",
-          type: "success",
-          hint: "Refresh the table.",
-          onClick: this.onClickRefreshSolutionsGrid.bind(this),
-        },
-        location: "after",
-      }
-    );
-
-    toolbarItems.push(
-      {
-        widget: "dxSelectBox",
-        options: {
-          placeholder: "Select Application",
-          value: this.selectedApplication?.Id,
-          hint: "Select an application from which solutions should be displayed.",
-          displayExpr: "Name",
-          onInitialized: (args: SelectBoxInitializedEvent) => {
-            this.applicationSelectBoxInstance = args.component;
-          },
-          onValueChanged: (e) => {
-            this.setSelectedApplicationId(e.value);
-          },
-          valueExpr: "Id",
-          width: "300",
-          dataSource: this.dataSourceApplications,
-        },
-        location: "before",
-      }
-    );
-
-    if(!this.userService.currentDbUserWithTenant.TenantNavigation.DisablePatchCreation){
-      toolbarItems.push(
-        {
-          location: "before",
-          widget: "dxButton",
-          options: {
-            text: "Add Patch",
-            icon: "add",
-            stylingMode: "contained",
-            type: "success",
-            disabled: this.selectedApplication == null ? true : false,
-            onClick: this.onClickAddPatch.bind(this),
-            onInitialized: (args: ButtonInitializedEvent) => {
-              this.addPatchButtonInstance = args.component;
-            },
-          },
-        }
-      );
-    }
-
-    toolbarItems.push(
-      {
-        location: "before",
-        widget: "dxButton",
-        options: {
-          text: "Add Upgrade",
-          icon: "add",
-          stylingMode: "contained",
-          type: "success",
-          disabled: this.selectedApplication == null ? true : false,
-          onClick: this.onClickAddUpgrade.bind(this),
-          onInitialized: (args: ButtonInitializedEvent) => {
-            this.addUpgradeButtonInstance = args.component;
-          },
-        },
-      }
-    );
   }
 
   public onClickConfigureDeployment(environment: Environment) {
@@ -664,6 +579,11 @@ export class SolutionsOverviewComponent implements OnInit, OnDestroy {
 
       this.applicationService.getApplicationById(id).then((application) => {
         this.selectedApplication = application;
+        this.selectedApplicationGroup = this.selectedApplication.Group ?? ungroupedApplicationLabel;
+        this.groupSelectBoxInstance?.option(
+          "value",
+          this.selectedApplicationGroup
+        );
         this.applicationSelectBoxInstance.option(
           "value",
           this.selectedApplication.Id
@@ -689,8 +609,179 @@ export class SolutionsOverviewComponent implements OnInit, OnDestroy {
       });
     } else if (id == null){
       localStorage.removeItem("atPowerCIDPortal_SolutionOverview_SelectedId");
+      this.clearSolutionsGrid();
       this.addPatchButtonInstance?.option("disabled", true);
       this.addUpgradeButtonInstance?.option("disabled", true);
     }
+  }
+
+  private createApplicationDataSource(group: string): DataSource {
+      const filter = group === ungroupedApplicationLabel
+        ? [
+          ["IsDeactive", "=", false],
+          "and",
+          [["Group", "=", null], "or", ["Group", "=", ""]],
+        ]
+        : group == null
+          ? ["IsDeactive", "=", false]
+          : [["IsDeactive", "=", false], "and", ["Group", "=", group]];
+
+      return new DataSource({
+        store: this.applicationService.getStore(),
+        sort: [
+          { selector: "OrdinalNumber", desc: false },
+          { selector: "Name", desc: false },
+        ],
+        filter,
+      });
+    }
+
+    private createSelectionToolbarItems(): unknown[] {
+      const items: unknown[] = [
+        {
+          widget: "dxSelectBox",
+          location: "before",
+          options: {
+            placeholder: "Select Group",
+            hint: "Select an application group.",
+            items: this.applicationGroups,
+            value: this.selectedApplicationGroup,
+            width: "220",
+            onInitialized: (args: SelectBoxInitializedEvent) => {
+              this.groupSelectBoxInstance = args.component;
+            },
+            onValueChanged: (e) => {
+              const selectedApplicationGroup = this.selectedApplication?.Group ?? ungroupedApplicationLabel;
+              if (this.selectedApplication != null && e.value === selectedApplicationGroup) {
+                return;
+              }
+              this.selectedApplicationGroup = e.value;
+              this.clearSolutionsGrid();
+              this.addPatchButtonInstance?.option("disabled", true);
+              this.addUpgradeButtonInstance?.option("disabled", true);
+              this.applicationSelectBoxInstance?.option("value", null);
+              this.applicationSelectBoxInstance?.option(
+                "dataSource",
+                this.createApplicationDataSource(e.value)
+              );
+            },
+          },
+        },
+        {
+          widget: "dxSelectBox",
+          location: "before",
+          options: {
+            placeholder: "Select Application",
+            value: this.selectedApplication?.Id,
+            hint: "Select an application from which solutions should be displayed.",
+            displayExpr: "Name",
+            onInitialized: (args: SelectBoxInitializedEvent) => {
+              this.applicationSelectBoxInstance = args.component;
+            },
+            onValueChanged: (e) => {
+              this.setSelectedApplicationId(e.value);
+            },
+            valueExpr: "Id",
+            width: "300",
+            dataSource: this.createApplicationDataSource(this.selectedApplicationGroup),
+          },
+        },
+      ];
+
+      if (!this.userService.currentDbUserWithTenant.TenantNavigation.DisablePatchCreation) {
+        items.push({
+          location: "before",
+          widget: "dxButton",
+          options: {
+            text: "Add Patch",
+            icon: "add",
+            stylingMode: "contained",
+            type: "success",
+            disabled: true,
+            onClick: this.onClickAddPatch.bind(this),
+            onInitialized: (args: ButtonInitializedEvent) => {
+              this.addPatchButtonInstance = args.component;
+            },
+          },
+        });
+      }
+
+      items.push(
+        {
+          location: "before",
+          widget: "dxButton",
+          options: {
+            text: "Add Upgrade",
+            icon: "add",
+            stylingMode: "contained",
+            type: "success",
+            disabled: true,
+            onClick: this.onClickAddUpgrade.bind(this),
+            onInitialized: (args: ButtonInitializedEvent) => {
+              this.addUpgradeButtonInstance = args.component;
+            },
+          },
+        },
+        {
+          location: "after",
+          widget: "dxButton",
+          options: {
+            icon: "refresh",
+            stylingMode: "contained",
+            type: "success",
+            hint: "Refresh the table.",
+            onClick: this.onClickRefreshSolutionsGrid.bind(this),
+          },
+        },
+        {
+          location: "after",
+          widget: "dxButton",
+          options: {
+            icon: "assets/animations/loading.gif",
+            text: "auto-refresh is active",
+            stylingMode: "text",
+            disabled: true,
+            visible: false,
+            onInitialized: (args: ButtonInitializedEvent) => {
+              this.autoRefreshHintButtonInstance = args.component;
+            },
+          },
+        },
+        {
+          location: "after",
+          widget: "dxButton",
+          options: {
+            icon: "clear",
+            stylingMode: "contained",
+            type: "success",
+            visible: false,
+            onClick: this.onClickCancelAutoRefresh.bind(this),
+            onInitialized: (args: ButtonInitializedEvent) => {
+              this.autoRefreshCancelButtonInstance = args.component;
+            },
+          },
+        }
+      );
+
+      return items;
+    }
+
+    private clearSolutionsGrid(): void {
+    this.selectedApplication = null;
+    this.cancelAutoRefresh();
+    this.showSolutionsGrid = false;
+    this.dataSourceSolutions = new DataSource({
+      store: this.solutionService.getStore(),
+      filter: ["Id", "=", -1],
+    });
+    this.dataGridColumns = [
+      {
+        caption: "Please select an application",
+        name: "no_data",
+      },
+    ];
+    setTimeout(() => {
+      this.showSolutionsGrid = true;
+    });
   }
 }

--- a/at.D365.PowerCID.Portal/ClientApp/src/app/components/solutions-overview/solutions-overview.component.ts
+++ b/at.D365.PowerCID.Portal/ClientApp/src/app/components/solutions-overview/solutions-overview.component.ts
@@ -587,6 +587,10 @@ export class SolutionsOverviewComponent implements OnInit, OnDestroy {
       this.applicationService.getApplicationById(id).then((application) => {
         this.selectedApplication = application;
         this.selectedApplicationGroup = this.selectedApplication.Group ?? null;
+        this.applicationSelectBoxInstance?.option(
+          "dataSource",
+          this.createApplicationDataSource(this.selectedApplicationGroup)
+        );
         this.groupSelectBoxInstance?.option(
           "value",
           this.selectedApplicationGroup

--- a/at.D365.PowerCID.Portal/ClientApp/src/app/shared/models/application.model.ts
+++ b/at.D365.PowerCID.Portal/ClientApp/src/app/shared/models/application.model.ts
@@ -9,6 +9,7 @@ export interface Application {
   Id?: number;
   OrdinalNumber?: number | null;
   Name?: string;
+  Group?: string;
   MsId?: string;
   SolutionUniqueName?: string;
   DevelopmentEnvironment?: number;

--- a/at.D365.PowerCID.Portal/Controllers/ApplicationsController.cs
+++ b/at.D365.PowerCID.Portal/Controllers/ApplicationsController.cs
@@ -130,7 +130,7 @@ namespace at.D365.PowerCID.Portal.Controllers
             if ((await this.dbContext.Applications.FirstOrDefaultAsync(e => e.Id == key && e.DevelopmentEnvironmentNavigation.TenantNavigation.MsId == this.msIdTenantCurrentUser)) == null)
                 return Forbid();
 
-            string[] propertyNamesAllowedToChange = { nameof(Application.DevelopmentEnvironment), nameof(Application.OrdinalNumber), nameof(Application.Name), nameof(Application.MsId), nameof(Application.InternalDescription), nameof(Application.ForceManagedDeployment), nameof(Application.AfterDeploymentInformation), nameof(Application.IsDeactive) };
+            string[] propertyNamesAllowedToChange = { nameof(Application.DevelopmentEnvironment), nameof(Application.OrdinalNumber), nameof(Application.Name), nameof(Application.Group), nameof(Application.MsId), nameof(Application.InternalDescription), nameof(Application.ForceManagedDeployment), nameof(Application.AfterDeploymentInformation), nameof(Application.IsDeactive) };
             if (application.GetChangedPropertyNames().Except(propertyNamesAllowedToChange).Count() != 0)
             {
                 return BadRequest();

--- a/at.D365.PowerCID.Portal/Data/Migrations/20260803150924_AddApplicationGroup.Designer.cs
+++ b/at.D365.PowerCID.Portal/Data/Migrations/20260803150924_AddApplicationGroup.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using at.D365.PowerCID.Portal.Data.Models;
 
@@ -11,9 +12,11 @@ using at.D365.PowerCID.Portal.Data.Models;
 namespace at.D365.PowerCID.Portal.Data.Migrations
 {
     [DbContext(typeof(atPowerCIDContext))]
-    partial class atPowerCIDContextModelSnapshot : ModelSnapshot
+    [Migration("20260803150924_AddApplicationGroup")]
+    partial class AddApplicationGroup
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/at.D365.PowerCID.Portal/Data/Migrations/20260803150924_AddApplicationGroup.cs
+++ b/at.D365.PowerCID.Portal/Data/Migrations/20260803150924_AddApplicationGroup.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace at.D365.PowerCID.Portal.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddApplicationGroup : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Group",
+                table: "Application",
+                type: "varchar(100)",
+                unicode: false,
+                maxLength: 100,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Group",
+                table: "Application");
+        }
+    }
+}

--- a/at.D365.PowerCID.Portal/Data/Models/Application.cs
+++ b/at.D365.PowerCID.Portal/Data/Models/Application.cs
@@ -15,6 +15,7 @@ namespace at.D365.PowerCID.Portal.Data.Models
         public int Id { get; set; }
         public int? OrdinalNumber { get; set; }
         public string Name { get; set; }
+        public string Group { get; set; }
         public Guid? MsId { get; set; }
         public string SolutionUniqueName { get; set; }
         public int DevelopmentEnvironment { get; set; }

--- a/at.D365.PowerCID.Portal/Data/Models/atPowerCIDContext.cs
+++ b/at.D365.PowerCID.Portal/Data/Models/atPowerCIDContext.cs
@@ -353,6 +353,10 @@ namespace at.D365.PowerCID.Portal.Data.Models
 
                 entity.Property(e => e.DevelopmentEnvironment).HasColumnName("Development Environment");
 
+                entity.Property(e => e.Group)
+                    .HasMaxLength(100)
+                    .IsUnicode(false);
+
                 entity.Property(e => e.ModifiedBy).HasColumnName("Modified By");
 
                 entity.Property(e => e.ModifiedOn).HasColumnName("Modified On");

--- a/at.D365.PowerCID.Portal/Startup.cs
+++ b/at.D365.PowerCID.Portal/Startup.cs
@@ -45,6 +45,7 @@ namespace at.D365.PowerCID.Portal
             builder.EntityType<Data.Models.Environment>().Property(e => e.IsDeactive);
             builder.EntitySet<Application>("Applications");
             builder.EntityType<Application>().Property(e => e.IsDeactive);
+            builder.EntityType<Application>().Property(e => e.Group);
             builder.EntitySet<Solution>("Solutions");
             builder.EntitySet<Publisher>("Publishers");
             builder.EntitySet<DeploymentPath>("DeploymentPaths");


### PR DESCRIPTION
Add an optional application group with database migration, group applications in the application overview, filter the solution overview by group, and keep the complete toolbar stable while switching groups.\n\nIssue: #167\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>